### PR TITLE
obs-filters: Fix Opacity in Mask/Blend filters

### DIFF
--- a/plugins/obs-filters/data/blend_add_filter.effect
+++ b/plugins/obs-filters/data/blend_add_filter.effect
@@ -3,6 +3,7 @@ uniform texture2d image;
 
 uniform texture2d target;
 uniform float4 color;
+uniform float opacity;
 uniform float2 mul_val;
 uniform float2 add_val;
 
@@ -37,7 +38,7 @@ float4 PSAddImageRGBA(VertDataOut v_in) : TARGET
 	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);
-	rgba.rgb = saturate(rgba.rgb + targetRGB.rgb);
+	rgba.rgb = lerp(rgba.rgb, saturate(rgba.rgb + targetRGB.rgb), opacity);
 	return rgba;
 }
 

--- a/plugins/obs-filters/data/blend_mul_filter.effect
+++ b/plugins/obs-filters/data/blend_mul_filter.effect
@@ -3,6 +3,7 @@ uniform texture2d image;
 
 uniform texture2d target;
 uniform float4 color;
+uniform float opacity;
 uniform float2 mul_val;
 uniform float2 add_val;
 
@@ -37,7 +38,7 @@ float4 PSMuliplyImageRGBA(VertDataOut v_in) : TARGET
 	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);
-	rgba.rgb = saturate(rgba.rgb * targetRGB.rgb);
+	rgba.rgb = lerp(rgba.rgb, saturate(rgba.rgb * targetRGB.rgb), opacity);
 	return rgba;
 }
 

--- a/plugins/obs-filters/data/blend_sub_filter.effect
+++ b/plugins/obs-filters/data/blend_sub_filter.effect
@@ -3,6 +3,7 @@ uniform texture2d image;
 
 uniform texture2d target;
 uniform float4 color;
+uniform float opacity;
 uniform float2 mul_val;
 uniform float2 add_val;
 
@@ -37,7 +38,7 @@ float4 PSSubtractImageRGBA(VertDataOut v_in) : TARGET
 	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);
-	rgba.rgb = saturate(rgba.rgb - targetRGB.rgb);
+	rgba.rgb = lerp(rgba.rgb, saturate(rgba.rgb - targetRGB.rgb), opacity);
 	return rgba;
 }
 

--- a/plugins/obs-filters/data/mask_alpha_filter.effect
+++ b/plugins/obs-filters/data/mask_alpha_filter.effect
@@ -3,6 +3,7 @@ uniform texture2d image;
 
 uniform texture2d target;
 uniform float4 color;
+uniform float opacity;
 uniform float2 mul_val;
 uniform float2 add_val;
 
@@ -37,7 +38,7 @@ float4 PSAlphaMaskRGBA(VertDataOut v_in) : TARGET
 	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);
-	rgba.a *= targetRGB.a;
+	rgba.a = lerp(rgba.a, rgba.a * targetRGB.a, opacity);
 	return rgba;
 }
 

--- a/plugins/obs-filters/data/mask_color_filter.effect
+++ b/plugins/obs-filters/data/mask_color_filter.effect
@@ -3,6 +3,7 @@ uniform texture2d image;
 
 uniform texture2d target;
 uniform float4 color;
+uniform float opacity;
 uniform float2 mul_val;
 uniform float2 add_val;
 
@@ -37,7 +38,7 @@ float4 PSColorMaskRGBA(VertDataOut v_in) : TARGET
 	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);
-	rgba.a *= (targetRGB.r + targetRGB.g + targetRGB.b) / 3.0;
+	rgba.a = lerp(rgba.a, rgba.a * ((targetRGB.r + targetRGB.g + targetRGB.b) / 3.0), opacity);
 	return rgba;
 }
 


### PR DESCRIPTION
Mask/Blend filters Opacity is changing the general opacity of the image
instead of changing the Opacity of the filter. We want Opacity to work
with alpha layers in Mask/Blend textures.